### PR TITLE
Add is.mas() and is.windowsStore()

### DIFF
--- a/is.js
+++ b/is.js
@@ -65,6 +65,14 @@ IsApi.prototype.dev = function () {
 IsApi.prototype.sandbox = function () {
   return 'APP_SANDBOX_CONTAINER_ID' in process.env
 }
+// Checks if the app is running as a Mac App Store build
+IsApi.prototype.mas = function () {
+  return process.mas === true
+}
+// Checks if the app is running as a Windows Store (appx) build
+IsApi.prototype.windowsStore = function () {
+  return process.windowsStore === true
+}
 
 // checks if all the 'is functions' passed as arguments are true
 IsApi.prototype.all = function (...isFunctions) {

--- a/test/test.html
+++ b/test/test.html
@@ -28,6 +28,8 @@
         assert.equal(is.dev(), (process.env.NODE_ENV || 'dev') === 'dev', 'is.dev() not ok!')
 
         assert.equal(is.sandbox(), ('APP_SANDBOX_CONTAINER_ID' in process.env), 'is.sandbox() not ok!')
+        assert.equal(is.mas(), process.mas === true, 'is.mas() not ok!')
+        assert.equal(is.windowsStore(), process.windowsStore === true, 'is.windowsStore() not ok!')
 
         assert.equal(is.all(is.osx, is.x64), is.osx() && is.x64(), 'is.all() 1 not ok!')
         assert.equal(is.all(is.osx, is.x86), is.osx() && is.x86(), 'is.all() 2 not ok!')

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,8 @@ function assertions (callback) {
   assert.equal(is.dev(), (process.env.NODE_ENV || 'dev') === 'dev', 'is.dev() not ok!')
 
   assert.equal(is.sandbox(), ('APP_SANDBOX_CONTAINER_ID' in process.env), 'is.sandbox() not ok!')
+  assert.equal(is.mas(), process.mas === true, 'is.mas() not ok!')
+  assert.equal(is.windowsStore(), process.windowsStore === true, 'is.windowsStore() not ok!')
 
   assert.equal(is.all(is.osx, is.x64), is.osx() && is.x64(), 'is.all() 1 not ok!')
   assert.equal(is.all(is.osx, is.x86), is.osx() && is.x86(), 'is.all() 2 not ok!')


### PR DESCRIPTION
In addition to the sandbox check (#1), I've just been made aware that the process object has these checks too.

https://github.com/electron/electron/blob/master/docs/api/process.md#processmas
https://github.com/electron/electron/blob/master/docs/api/process.md#processwindowsstore

Note that an app can be sandboxed without being on the Mac App Store, so I think these are still useful to have separately.