### PR TITLE
Added standardBrowser() function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Returns `true` if you are calling the function from the renderer process.
 - **is.main()**  
 Returns `true` if you are calling the function from the main process.
 
+- **is.standarBrowser()**  
+Return `true` if you are calling the function from a standar browser.
+
 - **is.macOS()** *aliases* **is.osx()**  
 Returns `true` if your app is running under Mac OS.
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Returns `true` if you are calling the function from the renderer process.
 - **is.main()**  
 Returns `true` if you are calling the function from the main process.
 
-- **is.standarBrowser()**  
-Return `true` if you are calling the function from a standar browser.
+- **is.standardBrowser()**  
+Return `true` if you are calling the function from a standard browser.
+This is an edge scenario, but maybe you are developing an electron app that you
+would like to use or test in browser as well, but still distinguish between them.
 
 - **is.macOS()** *aliases* **is.osx()**  
 Returns `true` if your app is running under Mac OS.

--- a/is.js
+++ b/is.js
@@ -33,7 +33,7 @@ IsApi.prototype.standardBrowser = function () {
     return true
   }
   // We have the process enabled or it is being mocked. So, are we in electron?
-  return !(this.renderer() || this.main())
+  return !process.hasOwnProperty('type')
 }
 
 // Checks if we are under Mac OS

--- a/is.js
+++ b/is.js
@@ -26,6 +26,10 @@ IsApi.prototype.main = function () {
   return process.type === 'browser'
 }
 
+IsApi.prototype.standardBrowser = function () {
+  return (typeof process === 'undefined')
+}
+
 // Checks if we are under Mac OS
 IsApi.prototype.osx = IsApi.prototype.macOS = function () {
   return process.platform === 'darwin'

--- a/is.js
+++ b/is.js
@@ -26,8 +26,14 @@ IsApi.prototype.main = function () {
   return process.type === 'browser'
 }
 
+// Checks if we are in a standard browser
 IsApi.prototype.standardBrowser = function () {
-  return (typeof process === 'undefined')
+  // We are in a browser enviroment, or with process disabled
+  if (typeof process === 'undefined') {
+    return true
+  }
+  // We have the process enabled or it is being mocked. So, are we in electron?
+  return !(this.renderer() || this.main())
 }
 
 // Checks if we are under Mac OS

--- a/test/test.html
+++ b/test/test.html
@@ -15,6 +15,7 @@
       ;(() => {
         assert.equal(is.main(), process.type === 'browser', 'is.main() not ok!')
         assert.equal(is.renderer(), process.type === 'renderer', 'is.renderer() not ok!')
+        assert.equal(is.standardBrowser(), false, 'is.standardBrowser() not ok!')
 
         assert.equal(is.osx(), process.platform === 'darwin', 'is.osx() not ok!')
         assert.equal(is.macOS(), process.platform === 'darwin', 'is.macOS() not ok!')

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,7 @@ ipc.on('all-test-passed', (event) => {
 function assertions (callback) {
   assert.equal(is.main(), process.type === 'browser', 'is.main() not ok!')
   assert.equal(is.renderer(), process.type === 'renderer', 'is.renderer() not ok!')
+  assert.equal(is.standardBrowser(), false, 'is.standardBrowser() not ok!')
 
   assert.equal(is.osx(), process.platform === 'darwin', 'is.osx() not ok!')
   assert.equal(is.macOS(), process.platform === 'darwin', 'is.macOS() not ok!')


### PR DESCRIPTION
I added this function based on my previous approach in `is-electron-renderer`. 

I think here it fells more natural, as you are asking explicitly if this is being called in the browser. 