### PR TITLE
Upgraded electron-is to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "standard": "^8.6.0"
   },
   "dependencies": {
-    "electron-is-dev": "^0.1.2",
+    "electron-is-dev": "^0.3.0",
     "semver": "^5.3.0"
   }
 }


### PR DESCRIPTION
Would previously install an earlier version and therefore display wrong information.
I ran into [that issue](https://github.com/sindresorhus/electron-is-dev/issues/5), and upgraded `electron-is-dev` to its latest version which eventually fixed it.